### PR TITLE
2025 03 31 readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ The `/resolved_json_schemas` folder includes JSON Schema payload files where all
 
 This version of the json schema files correspond to Data and Tools Guide version 1.2. (See Useful Links below.)
 
-### API endpoint to JSON Schema table
-| API POST endpoint | JSON schema filename |
+## API endpoint to JSON Schema table
+| API POST &amp; PUT endpoint | JSON schema filename |
 | ---- | ---- |
 | /applicants | applicantIdsPayload.schema.json |
 | /address-service/addresses | addressServicePayload.schema.json |
@@ -28,8 +28,8 @@ This version of the json schema files correspond to Data and Tools Guide version
 | /electric/reservations | electricReservationsPayload.schema.json |
 | /electric/reservations/{reservation_id}/extend | electricReservationsExpirationDateUpdatesPayload.schema.json |
 | /electric/reservations/{reservation_id}/files | electricFilesPayload.schema.json |
-| /electric/reservations/{reservation_id}/limited-assessments | electricLimitedAssessmentsPayload.schema.json |
 | /electric/reservations/{reservation_id}/install-redemptions | electricInstallRedemptionsPayload.schema.json |
+| /electric/reservations/{reservation_id}/limited-assessments | electricLimitedAssessmentsPayload.schema.json |
 | /electric/reservations/{reservation_id}/product-redemptions | electricProductRedemptionsPayload.schema.json |
 | /electric/reservations/{reservation_id}/state-addenda | electricStateAddendaPayload.schema.json |
 | /electric/vendor-coupons/product-redemptions | electricVendorCouponRedemptionsPayload.schema.json |

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ This repository maintains different branches that correspond to different API en
 - `prod+sandbox` - Contains the latest production-ready API schemas and documentation
 - `sandbox-test` - Contains schemas and documentation for the sandbox-test environment. This environment allows users to test new features and functionalities before they are released in production.
 
-Each branch reflects the current state of its respective environment. When making API integrations, ensure you're using the branch that corresponds to your target environment.
+Each branch reflects the current state of its respective environment. When making API integrations, ensure you're using the branch that corresponds to your target environment. 
+
+Both branches currently correspond to the Data and Tools Guide version 1.2. (See Useful Links below.)
 
 ## JSON Schema
 
 ### /json_schemas Folder 
 The `/json_schemas` folder includes JSON Schema files that are used by the IRA Rebate API to validate the JSON payload for each POST and PUT endpoint. API users may find these files useful as the most precise documentation regarding the allowed structure of the POST and PUT endpoint payloads. The schema files can also be used, together with a JSON Schema validator (see  https://json-schema.org/implementations), to validate the payloads before submitting to the API. This may be especially helpful during the development of client software.
-
-This version of the json schema files correspond to Data and Tools Guide version 1.2. (See Useful Links below.)
 
 ### /resolved_json_schemas Folder 
 The `/resolved_json_schemas` folder includes JSON Schema payload files where all referenced definitions are resolved. This provides a way to use an online JSON schema validator (such as https://www.liquid-technologies.com/online-json-schema-validator) to validate a POST payload.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The `/resolved_json_schemas` folder includes JSON Schema payload files where all
 ### IRA Rebates API Schema Documentation
 More human-readable documentation of the JSON Schema files is available at https://pnnl.github.io/IRA-Rebates-API. Be sure to choose the appropriate branch (environment) at the top of the page.
 
-## API endpoint to JSON Schema table
+### API Endpoint to JSON Schema Table
 | API POST &amp; PUT endpoint | JSON schema filename |
 | ---- | ---- |
 | /applicants | applicantIdsPayload.schema.json |

--- a/README.md
+++ b/README.md
@@ -44,6 +44,18 @@ More human-readable documentation of the JSON Schema files is available at https
 
 All other json schema files are referenced from those listed in the table. 
 
+## /hpxml_schematrons Folder
+The API validates HPXML v4.x files into steps:
+1. Validate against the HPXML v4.x XML Schema file, which can be obtained from https://github.com/hpxmlwg/hpxml.
+2. Validate against the appropriate IRA 50121 Rebate HPXML Schematron file from the /hpxml_schematrons folder.
+
+### file_type to Schematron Table
+| file_type from payload | Schematron filename |
+| ---- | ---- |
+| HPXML_MEASURED | measured_required.sch |
+| HPXML_MODELED_RECOMMENDED | modeled_recommended.sch |
+| HPXML_MODELED_REQUIRED | modeled_required.sch |
+
 ## Useful Links
 - Home Energy Rebate Programs: https://www.energy.gov/scep/home-energy-rebates-programs
 - Home Energy Rebate Tools (the high-level web page for the IRA Rebate API and related tools): https://www.pnnl.gov/projects/rebate-tools

--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ This version of the json schema files correspond to Data and Tools Guide version
 
 All other json schema files are referenced from those listed in the table. 
 
+## API Environments and Branches
+This repository maintains different branches that correspond to different API environments:
+- `prod+sandbox` - Contains the latest production-ready API schemas and documentation
+- `sandbox-test` - Contains schemas and documentation for the sandbox-test environment. This environment allows users to test new features and functionalities before they are released in production.
+
+Each branch reflects the current state of its respective environment. When making API integrations, ensure you're using the branch that corresponds to your target environment.
+
 ## Useful Links
 - Home Energy Rebate Programs: https://www.energy.gov/scep/home-energy-rebates-programs
 - Home Energy Rebate Tools (the high-level web page for the IRA Rebate API and related tools): https://www.pnnl.gov/projects/rebate-tools

--- a/README.md
+++ b/README.md
@@ -14,10 +14,13 @@ Each branch reflects the current state of its respective environment. When makin
 ### /json_schemas Folder 
 The `/json_schemas` folder includes JSON Schema files that are used by the IRA Rebate API to validate the JSON payload for each POST and PUT endpoint. API users may find these files useful as the most precise documentation regarding the allowed structure of the POST and PUT endpoint payloads. The schema files can also be used, together with a JSON Schema validator (see  https://json-schema.org/implementations), to validate the payloads before submitting to the API. This may be especially helpful during the development of client software.
 
+This version of the json schema files correspond to Data and Tools Guide version 1.2. (See Useful Links below.)
+
 ### /resolved_json_schemas Folder 
 The `/resolved_json_schemas` folder includes JSON Schema payload files where all referenced definitions are resolved. This provides a way to use an online JSON schema validator (such as https://www.liquid-technologies.com/online-json-schema-validator) to validate a POST payload.
 
-This version of the json schema files correspond to Data and Tools Guide version 1.2. (See Useful Links below.)
+### IRA Rebates API Schema Documentation
+More human-readable documentation of the JSON Schema files is available at https://pnnl.github.io/IRA-Rebates-API. Be sure to choose the appropriate branch (environment) at the top of the page.
 
 ## API endpoint to JSON Schema table
 | API POST &amp; PUT endpoint | JSON schema filename |

--- a/README.md
+++ b/README.md
@@ -9,10 +9,13 @@ This repository maintains different branches that correspond to different API en
 
 Each branch reflects the current state of its respective environment. When making API integrations, ensure you're using the branch that corresponds to your target environment.
 
-## JSON Schema 
-The `/json_schemas` folder includes JSON Schema files that are used by the IRA Rebate API to validate the JSON payload for each POST endpoint. API users may find these files useful as the most precise documentation regarding the allowed structure of the POST endpoint payloads. The schema files can also be used, together with a JSON Schema validator (see  https://json-schema.org/implementations), to validate the POST payloads before submitting to the API. This may be especially helpful during the development of client software.
+## JSON Schema
 
-Additionally, the `/resolved_json_schemas` folder includes JSON Schema payload files where all referenced definitions are resolved. This provides a way to use an online JSON schema validator (see https://www.liquid-technologies.com/online-json-schema-validator) to validate a POST payload.
+### /json_schemas Folder 
+The `/json_schemas` folder includes JSON Schema files that are used by the IRA Rebate API to validate the JSON payload for each POST and PUT endpoint. API users may find these files useful as the most precise documentation regarding the allowed structure of the POST and PUT endpoint payloads. The schema files can also be used, together with a JSON Schema validator (see  https://json-schema.org/implementations), to validate the payloads before submitting to the API. This may be especially helpful during the development of client software.
+
+### /resolved_json_schemas Folder 
+The `/resolved_json_schemas` folder includes JSON Schema payload files where all referenced definitions are resolved. This provides a way to use an online JSON schema validator (such as https://www.liquid-technologies.com/online-json-schema-validator) to validate a POST payload.
 
 This version of the json schema files correspond to Data and Tools Guide version 1.2. (See Useful Links below.)
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 This repository contains materials useful to users of the IRA Rebates API. The IRA Rebates API supports 50121 and 50122 of the DOE rebate programs authorized by the Inflation Reduction Act (IRA) of 2022. See https://www.energy.gov/scep/home-energy-rebates-programs for program descriptions and updates.
 
+## API Environments and Branches
+This repository maintains different branches that correspond to different API environments:
+- `prod+sandbox` - Contains the latest production-ready API schemas and documentation
+- `sandbox-test` - Contains schemas and documentation for the sandbox-test environment. This environment allows users to test new features and functionalities before they are released in production.
+
+Each branch reflects the current state of its respective environment. When making API integrations, ensure you're using the branch that corresponds to your target environment.
+
 ## JSON Schema 
 The `/json_schemas` folder includes JSON Schema files that are used by the IRA Rebate API to validate the JSON payload for each POST endpoint. API users may find these files useful as the most precise documentation regarding the allowed structure of the POST endpoint payloads. The schema files can also be used, together with a JSON Schema validator (see  https://json-schema.org/implementations), to validate the POST payloads before submitting to the API. This may be especially helpful during the development of client software.
 
@@ -30,13 +37,6 @@ This version of the json schema files correspond to Data and Tools Guide version
 | /homes/reservations/{reservation_id}/state-addenda | homesStateAddendaPayload.schema.json |
 
 All other json schema files are referenced from those listed in the table. 
-
-## API Environments and Branches
-This repository maintains different branches that correspond to different API environments:
-- `prod+sandbox` - Contains the latest production-ready API schemas and documentation
-- `sandbox-test` - Contains schemas and documentation for the sandbox-test environment. This environment allows users to test new features and functionalities before they are released in production.
-
-Each branch reflects the current state of its respective environment. When making API integrations, ensure you're using the branch that corresponds to your target environment.
 
 ## Useful Links
 - Home Energy Rebate Programs: https://www.energy.gov/scep/home-energy-rebates-programs


### PR DESCRIPTION
This PR includes several updates to the README file.

In the readme file, I refer to the folder containing the Schematron files as /hpxml_schemtrons. That file is currently named file_upload_schemas. We should rename it /hpxml_schematrons to match the README.  We should also remove the HPXML.xsd file from that folder. Users should get this schema file from the source instead.